### PR TITLE
task/sync: Refactor sync check, move check into sync instead of copy

### DIFF
--- a/task/generated.go
+++ b/task/generated.go
@@ -2933,6 +2933,7 @@ type SyncTask struct {
 	types.Update
 
 	// Output value
+	types.HandleObjCallback
 }
 
 // NewSync will create a SyncTask struct and fetch inherited data from parent task.

--- a/task/tasks.json
+++ b/task/tasks.json
@@ -386,6 +386,9 @@
       "SourcePath",
       "SourceStorage",
       "Update"
+    ],
+    "output": [
+      "HandleObjCallback"
     ]
   }
 }


### PR DESCRIPTION
If we do check in copy, every copy task run. It makes no sense for the callback func.